### PR TITLE
ci: use macos-latest

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -18,8 +18,8 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
           # import certificate and provisioning profile from secrets
-          echo -n "${{ secrets.BUILD_CERTIFICATE_BASE64 }}" | base64 --decode --output "${CERTIFICATE_PATH}"
-          echo -n "${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}" | base64 --decode --output "${PP_PATH}"
+          echo -n "${{ secrets.BUILD_CERTIFICATE_BASE64 }}" | base64 --decode -o "${CERTIFICATE_PATH}"
+          echo -n "${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}" | base64 --decode -o "${PP_PATH}"
 
           # create temporary keychain
           security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" $KEYCHAIN_PATH

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   build_with_signing:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   build_with_signing:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   build_with_signing:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -18,8 +18,8 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
           # import certificate and provisioning profile from secrets
-          echo -n "${{ secrets.BUILD_CERTIFICATE_BASE64 }}" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}" | base64 --decode --output $PP_PATH
+          echo -n "${{ secrets.BUILD_CERTIFICATE_BASE64 }}" | base64 --decode --output "${CERTIFICATE_PATH}"
+          echo -n "${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}" | base64 --decode --output "${PP_PATH}"
 
           # create temporary keychain
           security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" $KEYCHAIN_PATH


### PR DESCRIPTION
> the macOS 12 runner image will be removed by December 3rd, 2024

I guess we can use `latest` as we usually are using the latest OS version
